### PR TITLE
 Multiple optimizations to the viewer function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+$PBOPREFIX$

--- a/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
+++ b/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
@@ -22,13 +22,9 @@ params
 #define BUSY_BACKGROUND (DISPLAY displayCtrl 55000)
 #define BUSY_BACKGROUND_PRELOADING (DISPLAY displayCtrl 56000)
 
-switch (tolower _mode) do
+switch _mode do
 {
-        case ("exit"):
-        {
-                DISPLAY closeDisplay 2;
-        };
-        case ("onload"):
+        case "onload":
         {
                 _params params [["_display",displayNull,[displayNull]]];
                 uiNamespace setVariable ["asaayu_stringtable_display",_display];
@@ -37,51 +33,26 @@ switch (tolower _mode) do
                 missionNamespace setVariable ["stringtable_viewer_origin_index",0];
                 missionNamespace setVariable ["stringtable_viewer_language",language];
 
-                {
-                        if ((tolower configName _x) isEqualTo (tolower language)) then
-                        {
-                                missionNamespace setVariable ["stringtable_viewer_language_index",_foreachindex];
-                        };
-                } foreach ("true" configClasses (configfile >> "CfgLanguages"));
+                private _languages = ("true" configClasses (configfile >> "CfgLanguages")) apply {configname _x};
+                missionNamespace setVariable ["stringtable_viewer_language_index",_languages find language];
 
                 ["preload"] spawn STRINGTABLE_fnc_stringtable_viewer;
         };
-        case ("onunload"):
+        case "preload":
         {
-                _params params [["_display",displayNull,[displayNull]]];
-                _display closeDisplay 2;
-                uiNamespace setVariable ["asaayu_stringtable_display",displayNull];
-        };
-        case ("preload"):
-        {
-                private _check = (uiNamespace getVariable ["stringtable_viewer_allow_preload",true]);
-                if (_check) then
+                if (uiNamespace getVariable ["stringtable_viewer_allow_preload",true]) then
                 {
                         private _diag_ticktime = diag_ticktime;
 
                         startLoadingScreen [""];
-                        private _languages = ("true" configClasses (configfile >> "CfgLanguages"));
-                        private _origins = ("true" configClasses (configfile >> "cfgstringtables"));
-                        private _master = [];
-                        {
-                                private _config = _x;
-                                private _configname = configName _config;
-                                private _keys = ("true" configClasses (_config));
-                                private _data = [];
-                                {
-                                        private _key_text = [];
-                                        private _config = _x;
-                                        private _configname = configName _x;
-                                        {
-                                                // Need to parseText because some contin html entites :|
-                                                private _text = str (parseText (getText (_config >> (configName _x))));
-                                                _key_text pushBack _text
-                                        } foreach _languages;
-                                        _data pushBack [_configname,_key_text];
-                                } foreach _keys;
-
-                                _master pushBack [_configname, _data];
-                        } foreach _origins;
+                        private _languages = ("true" configClasses (configfile >> "CfgLanguages")) apply {configname _x};
+                        private _master = ("true" configClasses (configfile >> "cfgstringtables")) apply {
+                                [configname _x,("true" configClasses _x) apply {
+                                        private _key = _x;
+                                       [configname _x,_languages apply {str parseText getText(_key >> _x)}]
+                                }]
+                        };
+                        
                         uiNamespace setVariable ["stringtable_viewer_allow_preload",false];
                         uiNamespace setVariable ["stringtable_viewer_data",_master];
                         endLoadingScreen;
@@ -95,10 +66,14 @@ switch (tolower _mode) do
                 ["initgui"] call STRINGTABLE_fnc_stringtable_viewer;
                 ["eventhandlers"] call STRINGTABLE_fnc_stringtable_viewer;
                 ["loadstringtable"] spawn STRINGTABLE_fnc_stringtable_viewer;
+
+                SEARCH_EDIT ctrlSetText "";
+                SEARCH_EDIT ctrlSetTooltip "";
+                SEARCH_EDIT ctrlCommit 0;
         };
-        case ("initgui"):
+        case "initgui":
         {
-                private _languages = ("true" configClasses (configfile >> "CfgLanguages"));
+                private _languages = "true" configClasses (configfile >> "CfgLanguages");
                 {
                         private _name = getText (_x >> "name");
                         private _configname = configName _x;
@@ -109,7 +84,7 @@ switch (tolower _mode) do
                                 LANGUAGE_COMBO lbSetCurSel _index;
                         };
                 } foreach _languages;
-                private _origins = ("true" configClasses (configfile >> "cfgstringtables"));
+                private _origins = "true" configClasses (configfile >> "cfgstringtables");
                 {
                         private _name = getText (_x >> "displayName");
                         private _configname = configName _x;
@@ -120,83 +95,76 @@ switch (tolower _mode) do
 
                 SEARCH_EDIT ctrlSetText "";
 
-                { _x ctrlCommit 0 } foreach [LIST, SEARCH_EDIT, SEARCH_BUTTON, COPY_BUTTON, EXPORT_BUTTON, ORIGIN_COMBO, LANGUAGE_COMBO];
+                { _x ctrlCommit 0 } count [LIST, SEARCH_EDIT, SEARCH_BUTTON, COPY_BUTTON, EXPORT_BUTTON, ORIGIN_COMBO, LANGUAGE_COMBO];
         };
-        case ("eventhandlers"):
+        case "eventhandlers":
         {
-                STRINGTABLE_KEYDOWN_EVH = DISPLAY displayAddEventHandler ["KeyDown",{ ["keydown",_this] call STRINGTABLE_fnc_stringtable_viewer }];
-                ORIGIN_COMBO ctrlAddEventHandler ["LBSelChanged",{ ["lbselchanged",[0,(_this#1)]] call STRINGTABLE_fnc_stringtable_viewer }];
-                LANGUAGE_COMBO ctrlAddEventHandler ["LBSelChanged",{ ["lbselchanged",[1,(_this#1)]] call STRINGTABLE_fnc_stringtable_viewer }];
-                SEARCH_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["search",[tolower (ctrlText SEARCH_EDIT)]] spawn STRINGTABLE_fnc_stringtable_viewer }];
+                DISPLAY displayAddEventHandler ["KeyDown",{ ["keydown",_this] call STRINGTABLE_fnc_stringtable_viewer }];
+                ORIGIN_COMBO ctrlAddEventHandler ["LBSelChanged",{ ["lbselchanged",[0,_this#1]] call STRINGTABLE_fnc_stringtable_viewer }];
+                LANGUAGE_COMBO ctrlAddEventHandler ["LBSelChanged",{ ["lbselchanged",[1,_this#1]] call STRINGTABLE_fnc_stringtable_viewer }];
+                SEARCH_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["search",[tolower ctrlText SEARCH_EDIT]] spawn STRINGTABLE_fnc_stringtable_viewer }];
                 COPY_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["KeyDown",[nil,DIK_C,false,true]] call STRINGTABLE_fnc_stringtable_viewer }];
                 EXPORT_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["KeyDown",[nil,DIK_X,false,true]] call STRINGTABLE_fnc_stringtable_viewer }];
         };
-        case ("keydown"):
+        case "keydown":
         {
                 _params params ["_control", "_keydown_key", "_shift", "_ctrl", "_alt"];
-                private _key = (["getkey"] call STRINGTABLE_fnc_stringtable_viewer);
-                private _return = false;
-                switch (true) do
+                private _key = LIST lnbText [lbCurSel LIST,0];
+                switch true do
                 {
                         // Enter, Numpad Enter
                         case (_keydown_key in [DIK_RETURN,DIK_NUMPADENTER]):
                         {
-                                ["search",[tolower (ctrlText SEARCH_EDIT)]] spawn STRINGTABLE_fnc_stringtable_viewer;
-                                _return = true;
+                                ["search",[tolower ctrlText SEARCH_EDIT]] spawn STRINGTABLE_fnc_stringtable_viewer;
+                                true
                         };
                         // Ctrl-C
-                        case (_ctrl && {_keydown_key in [DIK_C] && {!(_key isEqualTo "")}}):
+                        case (_ctrl && {_keydown_key == DIK_C && {_key != ""}}):
                         {
                                 playSound "RscDisplayCurator_ping01";
                                 copyToClipboard format['%1',_key];
-                                _return = true;
+                                true
                         };
                         // Ctrl-X
-                        case (_ctrl && {_keydown_key in [DIK_X] && {!(_key isEqualTo "")}}):
+                        case (_ctrl && {_keydown_key == DIK_X && {_key != ""}}):
                         {
 
                                 playSound "RscDisplayCurator_ping06";
                                 copyToClipboard format['localize "%1"',_key];
-                                _return = true;
+                                true
                         };
+                        default {false};
                 };
-                _return
         };
-        case ("lbselchanged"):
+        case "lbselchanged":
         {
                 _params params ["_ctrl_index","_index"];
-                private _ctrl = ([ORIGIN_COMBO, LANGUAGE_COMBO] select _ctrl_index);
+                private _ctrl = [ORIGIN_COMBO, LANGUAGE_COMBO] select _ctrl_index;
                 private _old_variables = [stringtable_viewer_origin,stringtable_viewer_language];
-                switch (_ctrl_index) do
+                switch _ctrl_index do
                 {
                         // Origin
                         case 0:
                         {
-                                stringtable_viewer_origin = (_ctrl lbData _index);
+                                stringtable_viewer_origin = _ctrl lbData _index;
                                 stringtable_viewer_origin_index = _index;
                         };
                         // Language
                         case 1:
                         {
-                                stringtable_viewer_language = (_ctrl lbData _index);
+                                stringtable_viewer_language = _ctrl lbData _index;
                                 stringtable_viewer_language_index = _index;
                         };
                 };
                 if !(_old_variables isEqualTo [stringtable_viewer_origin,stringtable_viewer_language]) then
                 {
-                        ["search",[tolower (ctrlText SEARCH_EDIT)]] spawn STRINGTABLE_fnc_stringtable_viewer;
+                        ["search",[tolower ctrlText SEARCH_EDIT]] spawn STRINGTABLE_fnc_stringtable_viewer;
                 };
         };
-        case ("getkey"):
+        case "loadstringtable":
         {
-                private _index = lbCurSel LIST;
-                if (_index > -1) then
-                {
-                        (LIST lnbText [_index,0])
-                } else { "" };
-        };
-        case ("loadstringtable"):
-        {
+                _params params [["_search_term",""]];
+
                 lnbClear LIST;
 
                 private _diag_ticktime = diag_ticktime;
@@ -205,64 +173,23 @@ switch (tolower _mode) do
                 if (count _keys < 0) exitWith { systemchat "Error: View data < 0"; };
                 {
                         _x params ["_key","_text_list"];
-                        private _text = (_text_list#stringtable_viewer_language_index);
-                        private _row = LIST lnbAddRow [_key, _text, str 1];
-                        LIST lnbSetTooltip [[_row,0], _text];
+                        private _text = _text_list#stringtable_viewer_language_index;
+                        if (_search_term isEqualTo "" || {_search_term in toLower _key || _search_term in toLower _text}) then {
+                                private _row = LIST lnbAddRow [_key, _text, str 1];
+                                LIST lnbSetTooltip [[_row,0], _text];
+                        };
                 } foreach ((_keys#stringtable_viewer_origin_index)#1);
 
                 private _time = diag_ticktime - _diag_ticktime;
                 diag_log format[localize "STR_STRINGTABLE_INFO_DIAG_LOG",stringtable_viewer_origin,stringtable_viewer_language,str _time];
-
-                SEARCH_EDIT ctrlSetText "";
-                SEARCH_EDIT ctrlSetTooltip "";
-                SEARCH_EDIT ctrlCommit 0;
         };
-        case ("search"):
+        case "search":
         {
-                _params params ["_search_term"];
-
                 BUSY_BACKGROUND ctrlShow true;
                 ctrlSetFocus BUSY_BACKGROUND;
                 BUSY_BACKGROUND ctrlCommit 0;
 
-                private _diag_ticktime = diag_ticktime;
-
-                lnbClear LIST;
-                private _keys = uiNamespace getVariable ["stringtable_viewer_data",[]];
-                {
-                        _x params ["_key","_text_list"];
-                        private _original_key = _key;
-                        private _original_text = (_text_list#stringtable_viewer_language_index);
-                        private _text = toLower _original_text;
-                        private _key = toLower _original_key;
-                        private _value = switch (true) do
-                        {
-                                case (_search_term isEqualTo ""):
-                                {
-                                        1
-                                };
-                                case ((_key find _search_term) > -1):
-                                {
-                                        1
-                                };
-                                case ((_text find _search_term) > -1):
-                                {
-                                        1
-                                };
-                                default
-                                {
-                                        0
-                                };
-                        };
-                        if (_value > 0) then
-                        {
-                                private _row = LIST lnbAddRow [_original_key, _original_text, str 1];
-                                LIST lnbSetTooltip [[_row,0], _original_text];
-                        };
-                } foreach ((_keys#stringtable_viewer_origin_index)#1);
-
-                private _time = diag_ticktime - _diag_ticktime;
-                diag_log format[localize "STR_STRINGTABLE_INFO_DIAG_LOG",stringtable_viewer_origin,stringtable_viewer_language,str _time];
+                ["loadstringtable",_params] call stringtable_fnc_stringtable_viewer;
 
                 BUSY_BACKGROUND ctrlShow false;
                 BUSY_BACKGROUND ctrlCommit 0;

--- a/ui_f_stringtable/displays/3den.hpp
+++ b/ui_f_stringtable/displays/3den.hpp
@@ -1,26 +1,21 @@
-class display3DEN
-{
-       class Controls
-	{
-		class MenuStrip: ctrlMenuStrip
-		{
-			class Items
-			{
-                                items[] += {"stringtable_tools"};
-                                class Seperator;
-				class stringtable_tools
-				{
-                                        text = "Stringtable Viewer";
-					items[] =
-                                        {
-                                                "stringtable_open"
-                                        };
+class display3DEN {
+	class Controls {
+		class MenuStrip: ctrlMenuStrip {
+			class Items {
+				items[] += {
+					"stringtable_tools"
 				};
-                                class stringtable_open
-				{
+				class Seperator;
+				class stringtable_tools {
+					text = "Stringtable Viewer";
+					items[] = {
+						"stringtable_open"
+					};
+				};
+				class stringtable_open {
 					text = "Stingtable Viewer";
-                                        data = "stringtable_open_data";
-                                        opensNewWindow = 1;
+					data = "stringtable_open_data";
+					opensNewWindow = 1;
 					action = "(findDisplay 313) createDisplay 'stringtable_viewer';";
 				};
 			};

--- a/ui_f_stringtable/displays/stringtable_viewer.hpp
+++ b/ui_f_stringtable/displays/stringtable_viewer.hpp
@@ -2,7 +2,6 @@ class stringtable_viewer {
 	idd = 19995;
 	enableSimulation = 1;
 	onLoad = "['onload',_this] call stringtable_fnc_stringtable_viewer;";
-	onUnload = "['onunload',_this] call stringtable_fnc_stringtable_viewer;";
 	class controlsbackground {
 		class background_tiles: ctrlStaticBackgroundDisableTiles {};
 		class title: ctrlStaticTitle {

--- a/ui_f_stringtable/displays/stringtable_viewer.hpp
+++ b/ui_f_stringtable/displays/stringtable_viewer.hpp
@@ -1,108 +1,96 @@
-class stringtable_viewer
-{
-        idd = 19995;
-        enableSimulation = 1;
-        onLoad = "['onload',_this] call stringtable_fnc_stringtable_viewer;";
-        onUnload = "['onunload',_this] call stringtable_fnc_stringtable_viewer;";
-        class controlsbackground
-        {
-                class background_tiles: ctrlStaticBackgroundDisableTiles {};
-                class title: ctrlStaticTitle
-		{
+class stringtable_viewer {
+	idd = 19995;
+	enableSimulation = 1;
+	onLoad = "['onload',_this] call stringtable_fnc_stringtable_viewer;";
+	onUnload = "['onunload',_this] call stringtable_fnc_stringtable_viewer;";
+	class controlsbackground {
+		class background_tiles: ctrlStaticBackgroundDisableTiles {};
+		class title: ctrlStaticTitle {
 			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 6 * (pixelH * pixelGrid * 0.50)";
 			w = "188 * (pixelW * pixelGrid * 0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
 			text = $STR_STRINGTABLE_TITLE;
 		};
-                class background: ctrlStaticBackground
-		{
-                        x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
+		class background: ctrlStaticBackground {
+			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 12 * (pixelH * pixelGrid * 0.50)";
 			w = "188 * (pixelW * pixelGrid * 0.50)";
 			h = "132 * (pixelH * pixelGrid * 0.50)";
 		};
-                class stringtable_subtitle_background: background
-		{
+		class stringtable_subtitle_background: background {
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        colorBackground[] = {0,0,0,0.8};
-                };
-                class stringtable_list_background: stringtable_subtitle_background
-		{
+			colorBackground[] = {0,0,0,0.8};
+		};
+		class stringtable_list_background: stringtable_subtitle_background {
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 18 * (pixelH * pixelGrid * 0.50)";
 			h = "120 * (pixelH * pixelGrid * 0.50)";
-                        colorBackground[] = {0,0,0,0.55};
-                };
-        };
-        class controls
-        {
-                class exitButton: ctrlActivePicture
-		{
+			colorBackground[] = {0,0,0,0.55};
+		};
+	};
+	class controls {
+		class exitButton: ctrlActivePicture {
 			idc = 2;
 			text = "A3\Ui_f\data\GUI\Rsc\RscDisplayArcadeMap\icon_exit_cross_ca.paa";
-                        x = "((getResolution select 2) * 0.5 * pixelW) + 88 * (pixelW * pixelGrid * 0.50)";
+			x = "((getResolution select 2) * 0.5 * pixelW) + 88 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 6 * (pixelH * pixelGrid * 0.50)";
 			w = "6 * (pixelW * pixelGrid * 	0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
 			tooltip = "Close";
-			colorActive[] = {1, 1, 1, 1};
+			colorActive[] = {1,1,1,1};
 		};
-                class subtitle_key: ctrlStructuredText
-		{
-                        idc = 9999;
+		class subtitle_key: ctrlStructuredText {
+			idc = 9999;
 			text = $STR_STRINGTABLE_SUBTITLE_KEY;
-                        tooltip = $STR_STRINGTABLE_TOOLTIP_KEY;
-                        x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
+			tooltip = $STR_STRINGTABLE_TOOLTIP_KEY;
+			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 12 * (pixelH * pixelGrid * 0.50)";
 			w = "80 * (pixelW * pixelGrid *  0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        size = "5 * (pixelH * pixelGrid * 0.50)";
-                        sizeEx = "5 * (pixelH * pixelGrid * 0.50)";
-                        class Attributes
-        		{
-        			align = "left";
-        			color = "#ffffff";
-        			colorLink = "";
-        			size = 1;
-        			font = "PuristaBold";
-        		};
+			size = "5 * (pixelH * pixelGrid * 0.50)";
+			sizeEx = "5 * (pixelH * pixelGrid * 0.50)";
+			class Attributes {
+				align = "left";
+				color = "#ffffff";
+				colorLink = "";
+				size = 1;
+				font = "PuristaBold";
+			};
 		};
-                class subtitle_output: subtitle_key
-		{
-                        idc = 9998;
+		class subtitle_output: subtitle_key {
+			idc = 9998;
 			text = $STR_STRINGTABLE_SUBTITLE_OUTPUT;
 			tooltip = $STR_STRINGTABLE_TOOLTIP_OUTPUT;
-                        x = "((getResolution select 2) * 0.5 * pixelW) + 0 * (pixelW * pixelGrid * 0.50)";
+			x = "((getResolution select 2) * 0.5 * pixelW) + 0 * (pixelW * pixelGrid * 0.50)";
 			w = "80 * (pixelW * pixelGrid *  0.50)";
 		};
-                class subtitle_number: subtitle_key
-		{
-                        idc = 9997;
+		class subtitle_number: subtitle_key {
+			idc = 9997;
 			text = $STR_STRINGTABLE_SUBTITLE_NUMBER;
-                        x = "((getResolution select 2) * 0.5 * pixelW) + 66 * (pixelW * pixelGrid * 0.50)";
+			x = "((getResolution select 2) * 0.5 * pixelW) + 66 * (pixelW * pixelGrid * 0.50)";
 			w = "(18*0) * (pixelW * pixelGrid *  0.50)";
 		};
 
-                class stringtable_list: ctrlListNBox
-		{
-                        idc = 2000;
-                        x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
+		class stringtable_list: ctrlListNBox {
+			idc = 2000;
+			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 18 * (pixelH * pixelGrid * 0.50)";
 			w = "188 * (pixelW * pixelGrid *  0.50)";
 			h = "120 * (pixelH * pixelGrid * 0.50)";
 
 			blinkingPeriod = 0;
+			shadow = 0; // Shadow (0 - none, 1 - directional, color affected by colorShadow, 2 - black outline)
+
 			colorSelectBackground[] = {1,1,1,0.3}; // Selected item fill color
 			colorSelectBackground2[] = {1,1,1,0.3}; // Selected item fill color (oscillates between this and colorSelectBackground)
-			shadow = 0; // Shadow (0 - none, 1 - directional, color affected by colorShadow, 2 - black outline)
-			colorText[] = {1,1,1,1}; // Text and frame color
-			colorDisabled[] = {1,1,1,0.5}; // Disabled text color
-			colorSelect[] = {1,1,1,1}; // Text selection color
-			colorSelect2[] = {1,1,1,1}; // Text selection color (oscillates between this and colorSelect)
+			colorText[] = {1,1,1,1}; // Text and frame 
+			colorcolorDisabled[] = {1,1,1,0.5}; // Disabled text 
+			colorcolorSelect[] = {1,1,1,1}; // Text selection 
+			colorcolorSelect2[] = {1,1,1,1}; // Text selection color (oscillates between this and colorSelect)
 			colorShadow[] = {0,0,0,0.5}; // Text shadow color (used only when shadow is 1)
 
 			tooltip = ""; // Tooltip text
-			columns[] = {0, 0.5, 1}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
+			columns[] = {0,0.5,1}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
 
 			drawSideArrows = 0; // 1 to draw buttons linked by idcLeft and idcRight on both sides of selected line. They are resized to line height
 			idcLeft = -1; // Left button IDC
@@ -116,8 +104,7 @@ class stringtable_viewer
 			soundSelect[] = {"\A3\ui_f\data\sound\RscListbox\soundSelect",0.09,1}; // Sound played when an item is selected
 
 			// Scrollbar configuration (applied only when LB_TEXTURES style is used)
-			class ListScrollBar
-			{
+			class ListScrollBar {
 				width = 0; // width of ListScrollBar
 				height = 0; // height of ListScrollBar
 				scrollSpeed = 0.01; // scrollSpeed of ListScrollBar
@@ -130,108 +117,107 @@ class stringtable_viewer
 				color[] = {1,1,1,1}; // Scrollbar color
 			};
 		};
-                class stringtable_search_edit: ctrlEdit
-		{
+		class stringtable_search_edit: ctrlEdit {
 			idc = 3000;
-                        style = 512;
+			style = 512;
 			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
 			w = "40 * (pixelW * pixelGrid *  0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        tooltip = $STR_STRINGTABLE_TOOLTIP_EDIT_BOX;
-                        colorBackground[] = {0,0,0,0.4};
+			tooltip = $STR_STRINGTABLE_TOOLTIP_EDIT_BOX;
+			colorBackground[] = {
+				0,
+				0,
+				0,
+				0.4
+			};
 		};
-		class searchEditButton: ctrlButtonSearch
-		{
+		class searchEditButton: ctrlButtonSearch {
 			idc = 4000;
 			x = "((getResolution select 2) * 0.5 * pixelW) - 54 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
 			w = "6 * (pixelW * pixelGrid * 	0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        colorBackground[] = {0, 0, 0, 0};
-        		colorBackgroundDisabled[] = {0, 0, 0, 0};
-        		colorBackgroundActive[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.77])", "(profilenamespace getvariable ['GUI_BCG_RGB_G',0.51])", "(profilenamespace getvariable ['GUI_BCG_RGB_B',0.08])", 1};
-        		colorFocused[] = {0, 0, 0, 0};
-                        tooltip = $STR_STRINGTABLE_BUTTON_SEARCH;
+			colorBackground[] = {0,0,0,0};
+			colorBackgroundDisabled[] = {0,0,0,0};
+			colorBackgroundActive[] = {
+				"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.77])",
+				"(profilenamespace getvariable ['GUI_BCG_RGB_G',0.51])",
+				"(profilenamespace getvariable ['GUI_BCG_RGB_B',0.08])",
+				1
+			};
+			colorFocused[] = {0,0,0,0};
+			tooltip = $STR_STRINGTABLE_BUTTON_SEARCH;
 		};
-		class searchCopyButton: SearchEditButton
-		{
+		class searchCopyButton: SearchEditButton {
 			idc = 5000;
 			x = "((getResolution select 2) * 0.5 * pixelW) - 48 * (pixelW * pixelGrid * 0.50)";
-                        text = "\a3\3den\Data\Displays\Display3DEN\PanelLeft\entityList_duplicate_ca.paa";
-                        tooltip = $STR_STRINGTABLE_BUTTON_COPY;
+			text = "\a3\3den\Data\Displays\Display3DEN\PanelLeft\entityList_duplicate_ca.paa";
+			tooltip = $STR_STRINGTABLE_BUTTON_COPY;
 		};
-		class searchExportButton: SearchEditButton
-		{
+		class searchExportButton: SearchEditButton {
 			idc = 6000;
 			x = "((getResolution select 2) * 0.5 * pixelW) - 42 * (pixelW * pixelGrid * 0.50)";
-                        text = "\stringtable\ui_f_stringtable\data\export_to_clipboard_ca.paa";
-                        tooltip = $STR_STRINGTABLE_BUTTON_EXPORT;
+			text = "\stringtable\ui_f_stringtable\data\export_to_clipboard_ca.paa";
+			tooltip = $STR_STRINGTABLE_BUTTON_EXPORT;
 		};
-		class comboStringtable: CtrlCombo
-		{
+		class comboStringtable: CtrlCombo {
 			idc = 7000;
 			x = "((getResolution select 2) * 0.5 * pixelW) - 36 * (pixelW * pixelGrid * 0.50)";
-                        y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
+			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
 			w = "59 * (pixelW * pixelGrid * 0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        tooltip = $STR_STRINGTABLE_COMBO_ORIGIN;
+			tooltip = $STR_STRINGTABLE_COMBO_ORIGIN;
 		};
-		class comboLanguage: CtrlCombo
-		{
+		class comboLanguage: CtrlCombo {
 			idc = 8000;
 			x = "((getResolution select 2) * 0.5 * pixelW) + 23 * (pixelW * pixelGrid * 0.50)";
-                        y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
+			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
 			w = "59 * (pixelW * pixelGrid * 0.50)";
 			h = "6 * (pixelH * pixelGrid * 	0.50)";
-                        tooltip = $STR_STRINGTABLE_COMBO_LANGUAGE;
+			tooltip = $STR_STRINGTABLE_COMBO_LANGUAGE;
 		};
-                class helpIcon: ctrlStaticPicture
-		{
+		class helpIcon: ctrlStaticPicture {
 			text = "\stringtable\ui_f_stringtable\data\github_logo_light_ca.paa";
-                        x = "((getResolution select 2) * 0.5 * pixelW) + 82 * (pixelW * pixelGrid * 0.50)";
+			x = "((getResolution select 2) * 0.5 * pixelW) + 82 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
-                        w = "12 * (pixelW * pixelGrid * 0.50)";
+			w = "12 * (pixelW * pixelGrid * 0.50)";
 			h = "6 * (pixelH * pixelGrid * 0.50)";
-                        tooltip = $STR_STRINGTABLE_GITHUB_TOOLTIP;
+			tooltip = $STR_STRINGTABLE_GITHUB_TOOLTIP;
 		};
-                class helpLink: ctrlStructuredText
-		{
+		class helpLink: ctrlStructuredText {
 			x = "((getResolution select 2) * 0.5 * pixelW) + 80.5 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 138 * (pixelH * pixelGrid * 0.50)";
-                        w = "15.2 * (pixelW * pixelGrid * 0.50)";
+			w = "15.2 * (pixelW * pixelGrid * 0.50)";
 			h = "6 * (pixelH * pixelGrid * 0.50)";
-                        text = "<a href='https://github.com/Asaayu'>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</a>";
-                        fade = 1;
-                        class Attributes
-        		{
-        			align = "left";
-        			color = "#ffffff";
-        			colorLink = "";
-        			size = 0.4;
-        			font = "PuristaLight";
-        		};
+			text = "<a href='https://github.com/Asaayu'>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</a>";
+			fade = 1;
+			class Attributes {
+				align = "left";
+				color = "#ffffff";
+				colorLink = "";
+				size = 0.4;
+				font = "PuristaLight";
+			};
 		};
-                class background_busy: ctrlStatic
-		{
-                        idc = 55000;
-                        style = 2;
-                        text = $STR_STRINGTABLE_INFO_LOADING;
-                        font = "PuristaBold";
-                        x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
+		class background_busy: ctrlStatic {
+			idc = 55000;
+			style = 2;
+			text = $STR_STRINGTABLE_INFO_LOADING;
+			font = "PuristaBold";
+			x = "((getResolution select 2) * 0.5 * pixelW) - 94 * (pixelW * pixelGrid * 0.50)";
 			y = "0.5 - (safezoneH min (160 * (pixelH * pixelGrid * 0.50))) * 0.5 + 12 * (pixelH * pixelGrid * 0.50)";
 			w = "188 * (pixelW * pixelGrid * 0.50)";
 			h = "132 * (pixelH * pixelGrid * 0.50)";
-                        size = "10 * (pixelH * pixelGrid * 0.50)";
-                        sizeEx = "10 * (pixelH * pixelGrid * 0.50)";
-                        colorBackground[] = {0.2,0.2,0.2,0.7};
-                        show = 0;
+			size = "10 * (pixelH * pixelGrid * 0.50)";
+			sizeEx = "10 * (pixelH * pixelGrid * 0.50)";
+			colorBackground[] = {0.2,0.2,0.2,0.7};
+			show = 0;
 		};
-                class background_busy_preload: background_busy
-		{
-                        idc = 56000;
-                        text = $STR_STRINGTABLE_INFO_PRELOADING;
-                        show = 1;
+		class background_busy_preload: background_busy {
+			idc = 56000;
+			text = $STR_STRINGTABLE_INFO_PRELOADING;
+			show = 1;
 		};
-        };
+	};
 };


### PR DESCRIPTION
Improved performance of some tasks:
- Preloading data (after config rapify solution is implemented): 2856 ms -> 2393 ms
- Setting `stringtable_viewer_language_index`: 0.0481 ms -> 0.0259 ms
- Search filter performance: 0.0121 ms -> 0.0094 ms

Improved formatting of UI configs for better readability
Reduced codebase by ~70 lines to avoid unnecessary code duplicates and over-complication of tasks
