### PR TITLE
Update stringtable_viewer.hpp

### DIFF
--- a/ui_f_stringtable/displays/stringtable_viewer.hpp
+++ b/ui_f_stringtable/displays/stringtable_viewer.hpp
@@ -89,8 +89,9 @@ class stringtable_viewer {
 			colorShadow[] = {0,0,0,0.5}; // Text shadow color (used only when shadow is 1)
 
 			tooltip = ""; // Tooltip text
-			columns[] = {0,0.5,1}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
-
+			columns[] = {0,0.5,0.95}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
+			disableOverflow = true;
+			
 			drawSideArrows = 0; // 1 to draw buttons linked by idcLeft and idcRight on both sides of selected line. They are resized to line height
 			idcLeft = -1; // Left button IDC
 			idcRight = -1; // Right button IDC

--- a/ui_f_stringtable/displays/stringtable_viewer.hpp
+++ b/ui_f_stringtable/displays/stringtable_viewer.hpp
@@ -89,7 +89,7 @@ class stringtable_viewer {
 			colorShadow[] = {0,0,0,0.5}; // Text shadow color (used only when shadow is 1)
 
 			tooltip = ""; // Tooltip text
-			columns[] = {0,0.5,0.95}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
+			columns[] = {0,0.5,0.85}; // Horizontal coordinates of columns (relative to list width, in range from 0 to 1)
 			disableOverflow = true;
 			
 			drawSideArrows = 0; // 1 to draw buttons linked by idcLeft and idcRight on both sides of selected line. They are resized to line height


### PR DESCRIPTION
Moved last "fake" column to the left and added "disableOverflow". That way too long strings will not be displayed underneath the scroll bar.

*Might need testing if 0.85 is the correct position