### PR TITLE
Update fn_stringtable_viewer.sqf

### DIFF
--- a/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
+++ b/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
@@ -206,7 +206,7 @@ switch _mode do
 		missionNamespace setVariable ["stringtable_viewer_origin",ORIGIN_COMBO lbData 0];
 		missionNamespace setVariable ["stringtable_viewer_origin_index",0];
 
-		SEARCH_EDIT ctrlSetText "";
+		SEARCH_EDIT ctrlSetText localize "STR_STRINGTABLE_EDIT_SEARCH";
 
 		{ _x ctrlCommit 0 } count [LIST, SEARCH_EDIT, SEARCH_BUTTON, COPY_BUTTON, EXPORT_BUTTON, ORIGIN_COMBO, LANGUAGE_COMBO];
 	};
@@ -219,6 +219,8 @@ switch _mode do
 		COPY_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["keydown",[nil,DIK_C,false,true]] call STRINGTABLE_fnc_stringtable_viewer }];
 		EXPORT_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["keydown",[nil,DIK_X,false,true]] call STRINGTABLE_fnc_stringtable_viewer }];
 		CUSTOM_XML_BUTTON ctrlAddEventHandler ["ButtonClick",{ ["modifycustomxmlpaths",[]] call STRINGTABLE_fnc_stringtable_viewer }];
+		SEARCH_EDIT ctrlAddEventHandler ["SetFocus",{ ["focusSearch",[]] call STRINGTABLE_fnc_stringtable_viewer }];
+		SEARCH_EDIT ctrlAddEventHandler ["KillFocus",{ ["killFocusSearch",[]] call STRINGTABLE_fnc_stringtable_viewer }];
 	};
 	case "keydown":
 	{
@@ -367,5 +369,19 @@ switch _mode do
 
 		BUSY_BACKGROUND ctrlShow false;
 		BUSY_BACKGROUND ctrlCommit 0;
+	};
+	case "focusSearch":
+	{
+		if (ctrlText SEARCH_EDIT == localize "STR_STRINGTABLE_EDIT_SEARCH") then
+		{
+			SEARCH_EDIT ctrlSetText "";
+		};
+	};
+	case "killFocusSearch":
+	{
+		if (ctrlText SEARCH_EDIT == "") then
+		{
+			SEARCH_EDIT ctrlSetText localize "STR_STRINGTABLE_EDIT_SEARCH";
+		};
 	};
 };

--- a/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
+++ b/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
@@ -32,6 +32,7 @@ switch _mode do
 			["Arma 3",[
 				"\a3\3den_language\stringtable.xml",
 				"\a3\language_f_mod\stringtable.xml",
+				"\a3\language_f_mod\stringtable.xml",
 				"\a3\language_f_tank\stringtable.xml",
 				"\a3\language_f_mp_mark\stringtable.xml",
 				"\a3\languagemissions_f_mp_mark\stringtable.xml",
@@ -102,7 +103,7 @@ switch _mode do
 		["eventhandlers"] call STRINGTABLE_fnc_stringtable_viewer;
 		["loadstringtable"] spawn STRINGTABLE_fnc_stringtable_viewer;
 
-		SEARCH_EDIT ctrlSetText "";
+		SEARCH_EDIT ctrlSetText localize "STR_STRINGTABLE_EDIT_SEARCH";
 		SEARCH_EDIT ctrlSetTooltip "";
 		SEARCH_EDIT ctrlCommit 0;
 	};
@@ -350,7 +351,9 @@ switch _mode do
 		{
 			_x params ["_key","_text_list"];
 			private _text = _text_list#stringtable_viewer_language_index;
-			if (_search_term isEqualTo "" || {_search_term in toLower _key || _search_term in toLower _text}) then {
+			if (_search_term in ["",toLower localize "STR_STRINGTABLE_EDIT_SEARCH"] || {_search_term in toLower _key || {_search_term in toLower _text}}) then
+			{
+				
 				private _row = LIST lnbAddRow [_key, _text, ""];
 				LIST lnbSetTooltip [[_row,0], _text];
 			};

--- a/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
+++ b/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
@@ -32,7 +32,6 @@ switch _mode do
 			["Arma 3",[
 				"\a3\3den_language\stringtable.xml",
 				"\a3\language_f_mod\stringtable.xml",
-				"\a3\language_f_mod\stringtable.xml",
 				"\a3\language_f_tank\stringtable.xml",
 				"\a3\language_f_mp_mark\stringtable.xml",
 				"\a3\languagemissions_f_mp_mark\stringtable.xml",

--- a/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
+++ b/functions_f_stringtable/functions/fn_stringtable_viewer.sqf
@@ -207,7 +207,7 @@ switch _mode do
 		missionNamespace setVariable ["stringtable_viewer_origin",ORIGIN_COMBO lbData 0];
 		missionNamespace setVariable ["stringtable_viewer_origin_index",0];
 
-		SEARCH_EDIT ctrlSetText localize "STR_STRINGTABLE_EDIT_SEARCH";
+		SEARCH_EDIT ctrlSetText "";
 
 		{ _x ctrlCommit 0 } count [LIST, SEARCH_EDIT, SEARCH_BUTTON, COPY_BUTTON, EXPORT_BUTTON, ORIGIN_COMBO, LANGUAGE_COMBO];
 	};


### PR DESCRIPTION
- Search edit box will display a text by default which will better indicate that the user can use it to search
- When the search edit is focused, the text is removed (only if the default text is in the edit box, a custom entry won't be touched)